### PR TITLE
NFT Achievements System

### DIFF
--- a/Authentication & Authorization Module/users/users.controller.ts
+++ b/Authentication & Authorization Module/users/users.controller.ts
@@ -6,6 +6,9 @@ import { UserRole } from '../common/enums/user-role.enum';
 import { UsersService } from './users.service';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { AuditService } from '../audit/audit.service';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Nft } from '../../achievements/entities/nft.entity';
 
 @Controller('users')
 @UseGuards(JwtAuthGuard, RolesGuard)
@@ -13,16 +16,20 @@ export class UsersController {
   constructor(
     private readonly usersService: UsersService,
     private readonly auditService: AuditService,
+    @InjectRepository(Nft)
+    private readonly nftRepository: Repository<Nft>,
   ) {}
 
   @Get('profile')
   async getProfile(@CurrentUser() user: any) {
+    const nfts = await this.nftRepository.find({ where: { userId: user.id } });
     return {
       id: user.id,
       email: user.email,
       role: user.role,
       permissions: user.permissions,
       isActive: user.isActive,
+      nfts,
     };
   }
 

--- a/src/achievements/controllers/achievement.controller.spec.ts
+++ b/src/achievements/controllers/achievement.controller.spec.ts
@@ -1,0 +1,56 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AchievementController } from './achievement.controller';
+import { AchievementService } from '../services/achievement.service';
+import { NftService } from '../services/nft.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Nft } from '../entities/nft.entity';
+import { Repository } from 'typeorm';
+
+describe('AchievementController (NFTs)', () => {
+  let controller: AchievementController;
+  let nftRepository: Repository<Nft>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AchievementController],
+      providers: [
+        { provide: AchievementService, useValue: {} },
+        { provide: NftService, useValue: {} },
+        { provide: getRepositoryToken(Nft), useValue: { find: jest.fn(), findOne: jest.fn(), save: jest.fn(), create: jest.fn() } },
+      ],
+    }).compile();
+
+    controller = module.get<AchievementController>(AchievementController);
+    nftRepository = module.get(getRepositoryToken(Nft));
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('should return user NFTs', async () => {
+    const userId = 'user-1';
+    const mockNfts = [{ id: 'nft-1', userId }];
+    (nftRepository.find as jest.Mock).mockResolvedValue(mockNfts);
+    const result = await controller.getUserNfts(userId);
+    expect(result).toEqual(mockNfts);
+  });
+
+  it('should showcase an NFT', async () => {
+    const req = { user: { id: 'user-1' } };
+    const nft = { id: 'nft-1', userId: 'user-1', isShowcased: false };
+    (nftRepository.findOne as jest.Mock).mockResolvedValue(nft);
+    (nftRepository.save as jest.Mock).mockResolvedValue({ ...nft, isShowcased: true });
+    const result = await controller.showcaseNft('nft-1', req);
+    expect(result).toEqual({ message: 'NFT showcased' });
+  });
+
+  it('should set an NFT for trade', async () => {
+    const req = { user: { id: 'user-1' } };
+    const nft = { id: 'nft-1', userId: 'user-1', isForTrade: false };
+    (nftRepository.findOne as jest.Mock).mockResolvedValue(nft);
+    (nftRepository.save as jest.Mock).mockResolvedValue({ ...nft, isForTrade: true });
+    const result = await controller.setNftForTrade('nft-1', req);
+    expect(result).toEqual({ message: 'NFT set for trade' });
+  });
+});

--- a/src/achievements/entities/achievement.entity.ts
+++ b/src/achievements/entities/achievement.entity.ts
@@ -37,6 +37,15 @@ export class Achievement {
   @Column({ default: true })
   isActive: boolean;
 
+  @Column({ nullable: true })
+  nftImage: string;
+
+  @Column({ nullable: true })
+  nftExternalUrl: string;
+
+  @Column({ nullable: true })
+  nftAnimationUrl: string;
+
   @OneToMany(() => UserAchievement, userAchievement => userAchievement.achievement)
   userAchievements: UserAchievement[];
 

--- a/src/achievements/entities/nft.entity.ts
+++ b/src/achievements/entities/nft.entity.ts
@@ -1,0 +1,35 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, ManyToOne, JoinColumn, Index } from 'typeorm';
+
+@Entity('nfts')
+@Index(['userId', 'achievementId'])
+export class Nft {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  userId: string;
+
+  @Column()
+  achievementId: string;
+
+  @Column()
+  tokenId: string;
+
+  @Column()
+  contractAddress: string;
+
+  @Column({ nullable: true })
+  metadataUri: string;
+
+  @Column({ default: false })
+  isShowcased: boolean;
+
+  @Column({ default: false })
+  isForTrade: boolean;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/achievements/entities/user-achievement.entity.ts
+++ b/src/achievements/entities/user-achievement.entity.ts
@@ -25,6 +25,9 @@ export class UserAchievement {
   @Column({ type: 'timestamp', nullable: true })
   completedAt: Date;
 
+  @Column({ nullable: true })
+  nftId: string;
+
   @ManyToOne(() => Achievement, achievement => achievement.userAchievements)
   @JoinColumn({ name: 'achievementId' })
   achievement: Achievement;

--- a/src/achievements/services/nft.service.ts
+++ b/src/achievements/services/nft.service.ts
@@ -1,0 +1,34 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Nft } from '../entities/nft.entity';
+import { ethers } from 'ethers';
+
+@Injectable()
+export class NftService {
+  private readonly logger = new Logger(NftService.name);
+
+  // TODO: Inject config for provider, private key, contract address, ABI, etc.
+  // private provider: ethers.providers.JsonRpcProvider;
+  // private wallet: ethers.Wallet;
+  // private contract: ethers.Contract;
+
+  constructor() {
+    // TODO: Initialize provider, wallet, and contract
+  }
+
+  async mintAchievementNft(userId: string, achievementId: string, metadataUri: string): Promise<Partial<Nft>> {
+    // TODO: Call smart contract to mint NFT and return tokenId, contractAddress
+    // Example stub:
+    this.logger.log(`Minting NFT for user ${userId}, achievement ${achievementId}, metadata ${metadataUri}`);
+    return {
+      tokenId: 'mock-token-id',
+      contractAddress: '0xMockContractAddress',
+      metadataUri,
+    };
+  }
+
+  async transferNft(tokenId: string, toAddress: string): Promise<string> {
+    // TODO: Call smart contract to transfer NFT
+    this.logger.log(`Transferring NFT ${tokenId} to ${toAddress}`);
+    return 'mock-transaction-hash';
+  }
+}


### PR DESCRIPTION
## NFT Achievements System

closes #53 

- Users earn NFTs for specific achievements (e.g., trading wins, contributions)
- NFTs are minted and linked to achievements on completion
- Achievements and NFTs are displayed on user profiles
- Users can view, showcase, and set NFTs for trade
- Users can transfer (trade) NFTs to other users
- Public endpoint to view all showcased NFTs
- Admins can add new achievements with NFT metadata (image, external URL, animation)
- Includes tests for NFT endpoints and logic

**Note:** Blockchain minting is stubbed and ready for integration with a real smart contract.